### PR TITLE
chore: update dependencies in cypress and electron-playwright

### DIFF
--- a/cypress/package-lock.json
+++ b/cypress/package-lock.json
@@ -10,77 +10,77 @@
       "license": "MIT",
       "dependencies": {
         "@qavajs/cypress": "^2.8.0",
-        "@qavajs/cypress-runner-adapter": "^1.9.0",
+        "@qavajs/cypress-runner-adapter": "^1.9.1",
         "@qavajs/memory": "^1.10.3",
-        "allure": "^3.3.1",
-        "allure-cypress": "^3.6.0",
+        "allure": "^3.4.0",
+        "allure-cypress": "^3.7.0",
         "cross-env": "^10.1.0",
-        "cypress": "^15.11.0"
+        "cypress": "^15.13.1"
       }
     },
     "node_modules/@allurereport/aql": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.3.1.tgz",
-      "integrity": "sha512-adPJh1MyHQTJgGbkzb8Gdnx9aACKqL+HEHBLUbT9ltrHOow5fiT2hlHnreKQS0gPaeCmXZ5Aza21I5hezaKmnA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.4.0.tgz",
+      "integrity": "sha512-hMA0hJPyYilDrfzXMWDa/oyV8ODeexYoEmTp0FpAM/nl4hb+6ij3yy2DcmmM4+GORnq1H+bPeXStoN0sZchCTQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@allurereport/charts-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.3.1.tgz",
-      "integrity": "sha512-YZT9D4Nn2NZDK2NQxaVWeiwVDwiZSiBy/g7HRftTMfnl2cWs5tHN4AcU6SrVXPQ6BmcKqvYRetg6kXRzt3o9GA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.4.0.tgz",
+      "integrity": "sha512-tl664OVLhV3g4ZIJnzwbm+MKc26qCdXLQWADU+9LQhTWDJcJ9piu7dANqgSll3Gbf4eRd+1tcsCvUH3Bl5xMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "d3-shape": "^3.2.0"
       }
     },
     "node_modules/@allurereport/ci": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.3.1.tgz",
-      "integrity": "sha512-Hi+eo1X8ZFyFqW5+SEsGz971E6oNsyHWHZ/JsUt6qxxNtYXYVIvAWCef/Kg6nAsfj1FqjbIsYOz+QZ8N602BRw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.4.0.tgz",
+      "integrity": "sha512-HoJGp+UNgbYbtcQYMcwnK6tMfdEgsqqzW8Vo8eT67ZJfB/JBiT8rCkH9idZePHTvFOvkovdrEfu+encBn5rerQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0"
       }
     },
     "node_modules/@allurereport/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-JJJ8uQ3gr1RrmzPSFaY/Y5aQ9QSE5xfBP2TTmKs6dHMpPJhhI11BkAdK4jekjqxba2iBPxeh6oGbeMQgBlhk/w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-rL3HI5fBx6cPwtogss2U3olWLC05aqWPrc/4pCAQXx4lMyO4pgSW+gWiY1HOUxq/TVtH9vw8U+DUxCdTb24u4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/ci": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-allure2": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/plugin-awesome": "3.3.1",
-        "@allurereport/plugin-classic": "3.3.1",
-        "@allurereport/plugin-csv": "3.3.1",
-        "@allurereport/plugin-dashboard": "3.3.1",
-        "@allurereport/plugin-jira": "3.3.1",
-        "@allurereport/plugin-log": "3.3.1",
-        "@allurereport/plugin-progress": "3.3.1",
-        "@allurereport/plugin-slack": "3.3.1",
-        "@allurereport/plugin-testops": "3.3.1",
-        "@allurereport/plugin-testplan": "3.3.1",
-        "@allurereport/reader": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
-        "@allurereport/service": "3.3.1",
-        "@allurereport/summary": "3.3.1",
-        "handlebars": "^4.7.8",
+        "@allurereport/ci": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-allure2": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/plugin-awesome": "3.4.0",
+        "@allurereport/plugin-classic": "3.4.0",
+        "@allurereport/plugin-csv": "3.4.0",
+        "@allurereport/plugin-dashboard": "3.4.0",
+        "@allurereport/plugin-jira": "3.4.0",
+        "@allurereport/plugin-log": "3.4.0",
+        "@allurereport/plugin-progress": "3.4.0",
+        "@allurereport/plugin-slack": "3.4.0",
+        "@allurereport/plugin-testops": "3.4.0",
+        "@allurereport/plugin-testplan": "3.4.0",
+        "@allurereport/reader": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
+        "@allurereport/service": "3.4.0",
+        "@allurereport/summary": "3.4.0",
+        "handlebars": "^4.7.9",
         "node-stream-zip": "^1.15.0",
         "p-limit": "^7.2.0",
         "progress": "^2.0.3",
-        "yaml": "^2.8.1",
+        "yaml": "^2.8.3",
         "yoctocolors": "^2.1.1",
         "zip-stream": "^7.0.2"
       }
     },
     "node_modules/@allurereport/core-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.3.1.tgz",
-      "integrity": "sha512-BM+r1k4fYSIb4iE0H0BK7A79QMG7cp7u2+INk0XGJBdYNwHxqR3y3UIjL33VMABO9bIvuwykm7G3vL822GOedQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.4.0.tgz",
+      "integrity": "sha512-DQpMYOzrhGpM0v1JKNesQK9CFvdkfKyew/VZ4INe9df+xw0fKB+k4pta4XH7XnFcLSFyZCCDZuoiOoP/tdrWUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-shape": "^3.2.0"
@@ -114,160 +114,234 @@
       }
     },
     "node_modules/@allurereport/directory-watcher": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.3.1.tgz",
-      "integrity": "sha512-j2pt0WY12w50wVMe1af9ca4N8FTI1+CjxSS+cIekFYbFCk4RLLM8eK8Y9ZPvSm5DOd4nFHBJiF6Dzcpwo98mKQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.4.0.tgz",
+      "integrity": "sha512-knY4pvmCKzJ+FkZqgsovwPBxQPcaoHePwEKta9GvvzDVZDB0zM1e8PlSVlie1OuuIknqHW7W+JClK8jbmy3UUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "chokidar": "^4.0.3"
       }
     },
     "node_modules/@allurereport/plugin-allure2": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.3.1.tgz",
-      "integrity": "sha512-6BCGKILarxQxhIFQVVOSpaxcgfEfmTuOuSI5BBlW/rrUg/rQcVeCEZcWre4/jRUh7ReUpKznbPBOtf1Al/ZJRw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.4.0.tgz",
+      "integrity": "sha512-5ojSo8O4zbzuoMTCvw+v8ooeW8RG+dzBbwtbvbOTL/qf10e9qaRddXT4oUPu9gOOBELCGwv2CwflyZtokXfGpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-allure2": "3.3.1",
-        "handlebars": "^4.7.8"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "find-up": "^8.0.0",
+        "handlebars": "^4.7.9"
+      }
+    },
+    "node_modules/@allurereport/plugin-allure2/node_modules/find-up": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
+      "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^8.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/plugin-allure2/node_modules/locate-path": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
+      "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/plugin-allure2/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/plugin-allure2/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@allurereport/plugin-allure2/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@allurereport/plugin-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.3.1.tgz",
-      "integrity": "sha512-S5GxaqwiJRnb0Iq8ieTWaNh/aFtUJn5Gcv8zhgsZRHVtCB5CBGDUsHmnTYT494pjUDqbWW4TbnprwvjxC+2sXA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.4.0.tgz",
+      "integrity": "sha512-KGMhnVprTDoqX1a5V1IsLB5Zw8AomY4TWO7hcceODzlPoXnXauWRouqJmol+0X2tQePxQtDH9m0Bs8eZsAqX5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0"
       }
     },
     "node_modules/@allurereport/plugin-awesome": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.3.1.tgz",
-      "integrity": "sha512-QJuzVJLhaGbbmDuma8+VkEdKuYNhv17ya1mY86h1jHVDTjZPT3tvC+Qvq72xEuTVEXBmJ1yxXI8nwc2bkWj+kw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.4.0.tgz",
+      "integrity": "sha512-Y5tjzD1otHIeXBxWBpkG/lfuPzsWa4D00P1W/1wmjpp21djUdm+pSDBH/XAX0CRNxhpRwFmRvBym9tVhi6TB6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-awesome": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-awesome": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
         "d3-shape": "^3.2.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "markdown-it": "^14.1.0"
       }
     },
     "node_modules/@allurereport/plugin-classic": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.3.1.tgz",
-      "integrity": "sha512-GEtrqGWRFCL1hWzrzVMWN6OcR013S5OKBt2IR+A1txUsWJUzRDOyJx+MXHgarohshz50Ft3DzwiH+fXl0nVRdQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.4.0.tgz",
+      "integrity": "sha512-lIIwEHwsha8iuRWIU/iHZ4k4q3jwCsaDrKYjwbqGW2LIkdu5g4EsmS9tn98lhZRx9lHjt3J/12mY+Uz9mn2UAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-awesome": "3.3.1",
-        "@allurereport/web-classic": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-awesome": "3.4.0",
+        "@allurereport/web-classic": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
         "d3-shape": "^3.2.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "markdown-it": "^14.1.0"
       }
     },
     "node_modules/@allurereport/plugin-csv": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.3.1.tgz",
-      "integrity": "sha512-PKXnAVabArOrxTQNAKGywFlJV6Ok4wrZlT5q7Lu/LPNTgOVukq61jvVa2qeXnSrbMVhhkmyGOY2MNuuWw8RVCg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.4.0.tgz",
+      "integrity": "sha512-hjmVWL5ulpvS+Fay2Hik44pj0/QfD6ILeh0Spfj44hVgYc8pqSxXe3JGtY163HzqpyTJC8qPhDPX1qbfHh1xng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0"
       }
     },
     "node_modules/@allurereport/plugin-dashboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.3.1.tgz",
-      "integrity": "sha512-DW7B2FemB4WKaawFt+jba+UHUGb91I8YVPwAqKsNPPquI5G0zjbok/7t2XrKnEIisyq3UOEw2bLUPF15msrYQQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.4.0.tgz",
+      "integrity": "sha512-xWc6U2/KWYOW+MmkbE+Guz6iBZTGM3ogp+YyZ67D+VsmZwLgkdKp4vEREqj0GW3dXnci278XT79drBFDMmlXTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-dashboard": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-dashboard": "3.4.0",
         "d3-shape": "^3.2.0",
-        "handlebars": "^4.7.8"
+        "handlebars": "^4.7.9"
       }
     },
     "node_modules/@allurereport/plugin-jira": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.3.1.tgz",
-      "integrity": "sha512-2Kf9YQcg+M0ONMZeUk+XKj3dtEoezVdd6kIMUBfTxChje6eA6yfOl/pvgOx+ZQWn41U6N+WQHDvK9CaS29lL8w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.4.0.tgz",
+      "integrity": "sha512-PRZ7goz7F8lQJbNm0D71CmRCk26srhU8WEM5UvAU5tej3OA90Q/6vCKSL+pQ2MqXDVu2mPR+oqX1QcyQ+oyECQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "axios": "^1.13.5"
       }
     },
     "node_modules/@allurereport/plugin-log": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.3.1.tgz",
-      "integrity": "sha512-rSR5dt0ofJ2o26WrH1gcOXYP1gT0YbeZTC3OMGHD2jF74iblp+fzGD7duPBXhipttQS3/LUCrE7WFUknwHD7Ww==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.4.0.tgz",
+      "integrity": "sha512-lSL409x4OhtckhOBjJYY1HBlO0puJiSMNG4zCpnTsvIP+vo05niFiIPGr6wGKe14dmfcTF+YQRfPi6Nqhg8s4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "yoctocolors": "^2.1.1"
       }
     },
     "node_modules/@allurereport/plugin-progress": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.3.1.tgz",
-      "integrity": "sha512-UgiAKx2csc1Kxuj5nS2m6MngdA/i76MecwdNvP22K4ZYOhdpdzft4sdbepcL2mTUp0T7NHJv9mYeHzUaVMrMDA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.4.0.tgz",
+      "integrity": "sha512-3mIHQPl1UzALexeoRM03BSQ4BqEz1bIkE8r+LY2rrXSBrYNmsMWsKSl7fMq65BDusNDGO/IJVplkj9yrSGD+cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "yoctocolors": "^2.1.1"
       }
     },
     "node_modules/@allurereport/plugin-server-reload": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.3.1.tgz",
-      "integrity": "sha512-VocgkXf0Cm7NQ5MfwJ+OK98nE5PfsDz8ZjB+hwfHL4JP2DBRlmoStv46E3UpxWbPGR4lRyllqOxVuhMFFiX4ig==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.4.0.tgz",
+      "integrity": "sha512-/R6AsKGmLx7SEXGC2zZ9aa6rC+aZ3LecXjn3q1F2Q7PTWbRopEhDZBhnHWA5OpMEbyZPHIC3S8OKExL+57ntUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/static-server": "3.3.1"
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/static-server": "3.4.0"
       }
     },
     "node_modules/@allurereport/plugin-slack": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.3.1.tgz",
-      "integrity": "sha512-hacNNuhkwzKNYzXE2/Noi4fpden+h7P4+E9y0vpEFuOV7lYr8pbyjayw+Qt5IdY3NxHwD7kKKjLHOAhm0MBYlA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.4.0.tgz",
+      "integrity": "sha512-Y71EddWkOV1G3VxZPj2ai/EiDPSE2NJgjzov8FWLu59+HLFWCUQLj1y7nW3ZKZlvQVD9N4VvKr4pAxqeq7T8iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0"
       }
     },
     "node_modules/@allurereport/plugin-testops": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.3.1.tgz",
-      "integrity": "sha512-6+yO7tpmeXt2hzHlrdRCMF1PEkwKbb54mTXe9TxlJAXxYDYm8lT8Tn6GhwKv3ykmWPPLeuNWvi1mpNC9uj3ABQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.4.0.tgz",
+      "integrity": "sha512-KcJJmCt3UU2PeswKhvOHvtmWHQOOYsgCNM7H6e3PCQ0IX2Yb7uv82T7y2Qpf5TY5RsJ0p3BjimDWc4uWSshlNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/ci": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
+        "@allurereport/ci": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
         "axios": "^1.13.5",
         "form-data": "^4.0.5",
-        "lodash.chunk": "^4.2.0",
+        "lodash-es": "^4",
         "p-limit": "^7.3.0",
-        "progress": "^2.0.3"
+        "progress": "^2.0.3",
+        "yoctocolors": "^2"
       }
     },
     "node_modules/@allurereport/plugin-testops/node_modules/p-limit": {
@@ -298,131 +372,83 @@
       }
     },
     "node_modules/@allurereport/plugin-testplan": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.3.1.tgz",
-      "integrity": "sha512-Hz2972TjHD5Fpa4yuDkQpAZZA9l883xHkBvcHNVkH2e0ymwfINX/HTfbBr0CsgfJLOa3Sfgr255MdaBc8JEt4A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.4.0.tgz",
+      "integrity": "sha512-EcY+go2R+twHYrUsHJGsxUEg/J0HwiAvLTNClxBMllvXfwsNTVLu5p24NlteAhRUTFdYGoAnN1cw4s7s37DEbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0"
       }
     },
     "node_modules/@allurereport/reader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.3.1.tgz",
-      "integrity": "sha512-T6sGcwxo8+5tJBJFvbd9eSJGgQ8WNyk34LEHRrVV9KAsiBIz92WvLObV7jH1rbodVoWFbxZ6AZkzgoCwcfLchQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.4.0.tgz",
+      "integrity": "sha512-0RZhijmKAZAqYzrzWV5BPOu7b6p/UXyuRw+cuAw2Va1vu0I1I0ZuZvxQHaHV+I9TUmzpEP6mPx+JVttI5v35Dg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
-        "fast-xml-parser": "^5.3.6"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
+        "fast-xml-parser": "^5.5.7"
       }
     },
     "node_modules/@allurereport/reader-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.3.1.tgz",
-      "integrity": "sha512-Fbew7o4IkFrgifUEfWkxgR6KFnthmMxGVCz8CyQTUGciZJ/rixzwgvBH2rtSaoBiH4cWdjT52+q0aQHlX+1Tgg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.4.0.tgz",
+      "integrity": "sha512-HhBN48/frcJ4u27UmUFWCPGfVDauJ+8zNbIyME5RLnHSBAOVuV81DDMgp6EOQ3ETuo/+6GzvgY/oRZ+oc750bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "mime-types": "^2.1.35"
       }
     },
     "node_modules/@allurereport/service": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.3.1.tgz",
-      "integrity": "sha512-OjOYszEslSGs2grMcgUcG6C1UANySG9Y5t29bH01ZjGcNTb8v+PQe3Hg1U0GXmhvWFaMfrNMRGNlcbhoDaEvEw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.4.0.tgz",
+      "integrity": "sha512-tjMLo3MVWJrRluxaSFmbVgcxJvJWwgxXn86//2aU0MVUTDKXb47bXEYdJAcBAEpyk8q2yJObg11HUeZyk41aNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "axios": "^1.13.5",
         "open": "^10.1.0"
       }
     },
     "node_modules/@allurereport/static-server": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.3.1.tgz",
-      "integrity": "sha512-rsVkM8zAMDCHizRP6ldNhlasrrzZnhokosFTcwszhedlf67aGtSLF+xtuwZUd8m0a/r2n+1bNSEDJhpB8Aoi/g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.4.0.tgz",
+      "integrity": "sha512-S+mT7NG62f7XMVjleoL3ATICBgpWT3npZnDndb8FXhXyKGUy4PCke/vs6hdO1WBKAO0Fd+AwZKv9/PxSa0uHJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/directory-watcher": "3.3.1",
+        "@allurereport/directory-watcher": "3.4.0",
         "open": "^10.1.0"
       }
     },
     "node_modules/@allurereport/summary": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.3.1.tgz",
-      "integrity": "sha512-W7sMyqKAhJOyDm0Ktza5OAjGW9OAPv3/gwLQPwSeIJWrCnrlwb8jeE3dTd+GNP7s6Swx4jFJAfxxcs4N37k3Wg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.4.0.tgz",
+      "integrity": "sha512-/9Pj0SwOicDyKvmE2//Dhq+u9834j2i3JJQRlhi81Pf79VWPdekxBAT+g58E0T5OOvVfeKLttGYo7v9n/OEwKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-summary": "3.3.1",
-        "handlebars": "^4.7.8"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-summary": "3.4.0",
+        "handlebars": "^4.7.9"
       }
-    },
-    "node_modules/@allurereport/web-allure2": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-allure2/-/web-allure2-3.3.1.tgz",
-      "integrity": "sha512-MMcVVwqIY7X2nsI/7JvQlal4GtqPe2yVm37kqOkvt9X6rjLpq4tXTgHwceEEKIbzOmgvLGk6M9hzMJGkgOgBjw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@allurereport/web-commons": "3.3.1",
-        "@babel/runtime": "^7.27.6",
-        "b_": "^1.3.4",
-        "backbone": "^1.6.0",
-        "backbone.marionette": "^3.5.1",
-        "d3-array": "^3.2.4",
-        "d3-axis": "^3.0.0",
-        "d3-brush": "^3.0.0",
-        "d3-drag": "^3.0.0",
-        "d3-dsv": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.1.0",
-        "d3-selection": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "filesize": "^10.1.6",
-        "handlebars": "^4.7.8",
-        "highlight.js": "^10.7.3",
-        "i18next": "^8.4.3",
-        "jquery": "^3.7.1",
-        "postcss": "^8.5.6",
-        "sortablejs": "^1.15.3",
-        "split.js": "^1.6.5",
-        "underscore": "^1.13.7",
-        "url": "^0.11.4"
-      }
-    },
-    "node_modules/@allurereport/web-allure2/node_modules/backbone": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.6.1.tgz",
-      "integrity": "sha512-YQzWxOrIgL6BoFnZjThVN99smKYhyEXXFyJJ2lsF1wJLyo4t+QjmkLrH8/fN22FZ4ykF70Xq7PgTugJVR4zS9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "underscore": ">=1.8.3"
-      }
-    },
-    "node_modules/@allurereport/web-allure2/node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT"
     },
     "node_modules/@allurereport/web-awesome": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.3.1.tgz",
-      "integrity": "sha512-tf8PVcRKY33pVRcNGvFBAbwa0VH/YZwZ7cA/4ytdLGH4TW6bHQ4HNR9yp+LWpwUvl+ONXjKExc0wxJV/AtSjjQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.4.0.tgz",
+      "integrity": "sha512-FsyvWnNzRhSI/jda2zuO+TLaefWorKDDn6IX2bK2eRhlqzgbVnwTpHwH/InnG0/5QXBVi7KWNZnkSh9zbP95SQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "d3-shape": "^3.2.0",
@@ -432,47 +458,16 @@
         "prismjs": "^1.30.0"
       }
     },
-    "node_modules/@allurereport/web-awesome/node_modules/i18next": {
-      "version": "24.2.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.10"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@allurereport/web-classic": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.3.1.tgz",
-      "integrity": "sha512-SthPjBwZYgqzEFB9IvjCYdJk3WQee1iN71WDSVj3v9COcp7icXJMPW+7uc8Z63TNLWYgoHZ7Xm4DMYoabb2wcw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.4.0.tgz",
+      "integrity": "sha512-8q98s9U6a2fHYoksIfWYdKkoRvsZRvLriqj34fGkOWag4dq6tbDi+jK6F4/3FCfZCbs5M62GuiHnnx1YkPbYcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "d3-shape": "^3.2.0",
@@ -483,65 +478,34 @@
         "split.js": "^1.6.5"
       }
     },
-    "node_modules/@allurereport/web-classic/node_modules/i18next": {
-      "version": "24.2.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.10"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@allurereport/web-commons": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.3.1.tgz",
-      "integrity": "sha512-ZlO4H4TEvnAKLRWxusGW4+ahnm2MwjCOBd7LwL+gf7PfE0JmHXDFatMr6b4Kix0RgsDvpay9qPQ6LtUm4bKYbA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.4.0.tgz",
+      "integrity": "sha512-Jo7cbvoDwWq/herqCCjsKdOQKXKx6nnBuP+R6AWcePU0evmlXMSNUA/a9QvgFkI6gucIsxbKDa5GG01+mo5gEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/aql": "3.3.1",
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/aql": "3.4.0",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "@preact/signals": "^2.6.1",
         "@preact/signals-core": "^1.12.2",
         "ansi-to-html": "^0.7.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-shape": "^3.2.0",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.3.2",
         "nanoid": "^5.1.6"
       }
     },
     "node_modules/@allurereport/web-components": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.3.1.tgz",
-      "integrity": "sha512-oxHR671VqmA5h/KZZmqYufZa3dBAYDo6gVs8phkgDI04GnmBUSo38rIRuwnvYyHAuueV4wsA05vQxn8BJTDM8g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.4.0.tgz",
+      "integrity": "sha512-3Pzp04ZS6xfnh3D8TRpMZ2RSukWrHYxUr+vnYAzNVs7jU9L/PrV5H2HGD+5ssYay9it3JQ306qRkdOpWDFkQwg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
         "@floating-ui/dom": "^1.7.4",
         "@nivo/bar": "^0.99.0",
         "@nivo/core": "^0.99.0",
@@ -578,96 +542,34 @@
       }
     },
     "node_modules/@allurereport/web-dashboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.3.1.tgz",
-      "integrity": "sha512-APX7W4xnNK6bImuVUwPOUIrC0Y0N3ertIUgkFBy8+mzuenxCBI1e9oJOyqiZna5GNz9kKsYMhBNwgza2LCKuFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.4.0.tgz",
+      "integrity": "sha512-smPiLsYP96xOe98XuFiT20NRF4ublc8ADOgGGOTACPluDok/40VI0XUwDV4rORvpSXIvOxNvoTtqz8yGA4ycnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "i18next": "^24.0.2",
         "preact": "^10.28.2"
-      }
-    },
-    "node_modules/@allurereport/web-dashboard/node_modules/i18next": {
-      "version": "24.2.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.10"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@allurereport/web-summary": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.3.1.tgz",
-      "integrity": "sha512-R+YL2tjgQoyNs3qO85ZY3VdHXoN3CPDkU/lxUd60rGhvvIK7UDTMgHmCbU/ttW/O5hkR+qVXrrG22c3aMmR3oQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.4.0.tgz",
+      "integrity": "sha512-1jBiKCnxjJP4nzUUGWRtoCKkpdtNxhDMMu5FcfKB6fJsI3lvIQfO+qlcg3ln0Vx7B6MHlY/5VmvOtVvTbUCkQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "i18next": "^24.0.2",
         "preact": "^10.28.2"
-      }
-    },
-    "node_modules/@allurereport/web-summary/node_modules/i18next": {
-      "version": "24.2.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.10"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2137,9 +2039,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2316,28 +2218,28 @@
       "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -2776,12 +2678,12 @@
       }
     },
     "node_modules/@preact/signals": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.8.1.tgz",
-      "integrity": "sha512-wX6U0SpcCukZTJBs5ChljvBZb3XmYzA5gd4vKHgX8wZZKaQCo2WHtmThdLx+mcVvlBa5u3XShC7ffbETJD4BiQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.0.tgz",
+      "integrity": "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==",
       "license": "MIT",
       "dependencies": {
-        "@preact/signals-core": "^1.13.0"
+        "@preact/signals-core": "^1.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2792,9 +2694,9 @@
       }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
-      "integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2808,30 +2710,15 @@
       "license": "MIT"
     },
     "node_modules/@qavajs/cypress-runner-adapter": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@qavajs/cypress-runner-adapter/-/cypress-runner-adapter-1.9.0.tgz",
-      "integrity": "sha512-5MHvGzN4Z2j8zAUOF7ByHD/IN34hi5bnOcEDQTuIaWFG0k9X9SPabPS+4Di1TwMWvZE95sRwk3eW4iry3NgPWA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@qavajs/cypress-runner-adapter/-/cypress-runner-adapter-1.9.1.tgz",
+      "integrity": "sha512-2GrT+Dpm4n51f8XBHBR0GKpbHCooRfzQbT8pQmpgNIbigceKmPJkLddJ9MmsQDsfKGvro+YK+OgHfQ8k8ysLew==",
       "license": "MIT",
       "dependencies": {
         "@cucumber/cucumber-expressions": "^19.0.0",
         "@cucumber/gherkin": "^39.0.0",
         "@cucumber/tag-expressions": "^9.1.0",
-        "@cypress/webpack-preprocessor": "^7.0.2",
-        "fs-extra": "^11.3.4"
-      }
-    },
-    "node_modules/@qavajs/cypress-runner-adapter/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
+        "@cypress/webpack-preprocessor": "^7.0.2"
       }
     },
     "node_modules/@qavajs/memory": {
@@ -3346,30 +3233,30 @@
       }
     },
     "node_modules/allure": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/allure/-/allure-3.3.1.tgz",
-      "integrity": "sha512-wH2ZiJil1wzhbHN9jLkxXM/PLw2pxjTIzV/lDSyIHUGNYsDQb1cioE7eJRNDTL5cYTeoPpJL1IhsBfKFE2R8ZA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/allure/-/allure-3.4.0.tgz",
+      "integrity": "sha512-MeU2BuMJt+M94qXS03RCgzDIw+gU8H8Yxl4840vgBi+EDSpcCcl/U3CslxOw9Y/fwte74yqQZu5oRa2hkCwEdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/ci": "3.3.1",
-        "@allurereport/core": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/directory-watcher": "3.3.1",
-        "@allurereport/plugin-allure2": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/plugin-awesome": "3.3.1",
-        "@allurereport/plugin-classic": "3.3.1",
-        "@allurereport/plugin-csv": "3.3.1",
-        "@allurereport/plugin-dashboard": "3.3.1",
-        "@allurereport/plugin-jira": "3.3.1",
-        "@allurereport/plugin-log": "3.3.1",
-        "@allurereport/plugin-progress": "3.3.1",
-        "@allurereport/plugin-server-reload": "3.3.1",
-        "@allurereport/plugin-slack": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
-        "@allurereport/service": "3.3.1",
-        "@allurereport/static-server": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/ci": "3.4.0",
+        "@allurereport/core": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/directory-watcher": "3.4.0",
+        "@allurereport/plugin-allure2": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/plugin-awesome": "3.4.0",
+        "@allurereport/plugin-classic": "3.4.0",
+        "@allurereport/plugin-csv": "3.4.0",
+        "@allurereport/plugin-dashboard": "3.4.0",
+        "@allurereport/plugin-jira": "3.4.0",
+        "@allurereport/plugin-log": "3.4.0",
+        "@allurereport/plugin-progress": "3.4.0",
+        "@allurereport/plugin-server-reload": "3.4.0",
+        "@allurereport/plugin-slack": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
+        "@allurereport/service": "3.4.0",
+        "@allurereport/static-server": "3.4.0",
         "adm-zip": "^0.5.16",
         "clipanion": "^4.0.0-rc.4",
         "glob": "^11.1.0",
@@ -3383,12 +3270,12 @@
       }
     },
     "node_modules/allure-cypress": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/allure-cypress/-/allure-cypress-3.6.0.tgz",
-      "integrity": "sha512-a6t8v9B2K/Pn8ROeOzMbua5yd9HKy4VXfzxiiBB6hYYZPndaWrcE/v/obZIMBi5tCDnMDbWGfcwjTPKUI0+azQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/allure-cypress/-/allure-cypress-3.7.0.tgz",
+      "integrity": "sha512-z2D6CJGC0Z8SEg56FgZbDmsASn+C43qoAd2rNEm1dKn0DL3AbEJghRZKuzNr0OmPwZUll9y7QVcuRfs1oq6RRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "allure-js-commons": "3.6.0"
+        "allure-js-commons": "3.7.0"
       },
       "peerDependencies": {
         "cypress": ">=12.17.4"
@@ -3400,15 +3287,15 @@
       }
     },
     "node_modules/allure-js-commons": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.6.0.tgz",
-      "integrity": "sha512-RquIzMlh2l+ZLtq+Uxt+ZpOptxLzyPvLfPGbwU7dtgXo0QfUvhLFFkCljIR7Gjxo7jZ+WVqoto1yOPpXqU/i4g==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.7.0.tgz",
+      "integrity": "sha512-cDjqmSIDhpk0AFktb7/qwAk4D3To8S0bmPROq0hS5dDby+uXf6ir4WyXI0HC/rHS9+smidyFHwBod3yIQ8kZ4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "allure-playwright": "3.6.0"
+        "allure-playwright": "3.7.0"
       },
       "peerDependenciesMeta": {
         "allure-playwright": {
@@ -3556,29 +3443,23 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
-    "node_modules/b_": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/b_/-/b_-1.3.4.tgz",
-      "integrity": "sha512-IYgNQdGx8RgDMYXMF1L2KC+HHHBD4FuIqkGBBPDd+KiGTy/1eWrNlZnvfQh0RZGcDglmSus2eqb3ISW0nvYHsg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=10"
       }
     },
     "node_modules/babel-loader": {
@@ -3640,38 +3521,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/backbone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
-      "integrity": "sha512-aK+k3TiU4tQDUrRCymDDE7XDFnMVuyE6zbZ4JX7mb4pJbQTVOH997/kyBzb8wB2s5Y/Oh7EUfj+sZhwRPxWwow==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "underscore": ">=1.8.3"
-      }
-    },
-    "node_modules/backbone.marionette": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-3.5.1.tgz",
-      "integrity": "sha512-1eegQCV+Bn+G7uXRkN3llajwxW+2dPGrMy189+S0UUJjN1vDhCZBBMwwhzVhpGX5vKTzM/q6rOEYAbJxvOkVXA==",
-      "license": "MIT",
-      "dependencies": {
-        "backbone.radio": "^2.0.0"
-      },
-      "peerDependencies": {
-        "backbone": "~1.3.3",
-        "underscore": "~1.8.3"
-      }
-    },
-    "node_modules/backbone.radio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/backbone.radio/-/backbone.radio-2.0.0.tgz",
-      "integrity": "sha512-SHdSh2OaWqalbYi1sXvbTtnRFym5AV9loybNi2Q1iHkU2vveQDlWsmDn9l8onmfR6ZkemuYgHLgtfAYKfyfBZg==",
-      "peerDependencies": {
-        "backbone": "^1.3.3",
-        "underscore": "^1.8.3"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3730,9 +3579,9 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4226,9 +4075,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.11.0.tgz",
-      "integrity": "sha512-NXDE6/fqZuzh1Zr53nyhCCa4lcANNTYWQNP9fJO+tzD3qVTDaTUni5xXMuigYjMujQ7CRiT9RkJJONmPQSsDFw==",
+      "version": "15.13.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
+      "integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4373,40 +4222,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/d3-ease": {
@@ -4662,9 +4477,9 @@
       }
     },
     "node_modules/delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -4680,13 +4495,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -5011,21 +4823,9 @@
       "peer": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -5034,8 +4834,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
+      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.4.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5061,15 +4877,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/filesize": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
-      "integrity": "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 10.4.0"
       }
     },
     "node_modules/find-up": {
@@ -5318,9 +5125,9 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -5410,15 +5217,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/http-signature": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
@@ -5442,21 +5240,34 @@
       }
     },
     "node_modules/i18next": {
-      "version": "8.4.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-8.4.3.tgz",
-      "integrity": "sha512-V6HKLWSh2d/CSie1s/TErgEIdu/gPRUGJo/kBRcOW+YH2fnwMl3ByIMGsKSO5qajThceQ9AghZQ+OsGVS492/g==",
-      "license": "MIT"
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "@babel/runtime": "^7.26.10"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ieee754": {
@@ -5673,12 +5484,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5845,15 +5650,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -6074,9 +5879,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
-      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
       "funding": [
         {
           "type": "github",
@@ -6256,6 +6061,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
+      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6311,7 +6131,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/pify": {
       "version": "2.3.0",
@@ -6321,56 +6142,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/preact": {
-      "version": "10.28.4",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
-      "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6440,12 +6215,6 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT"
     },
     "node_modules/punycode.js": {
       "version": "2.3.1",
@@ -6693,9 +6462,9 @@
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
     "node_modules/run-applescript": {
@@ -6709,12 +6478,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -6910,15 +6673,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -7003,9 +6757,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -7261,13 +7015,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -7317,6 +7064,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -7364,23 +7123,10 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/url": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.4.1",
-        "qs": "^6.12.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/use-debounce": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
-      "integrity": "sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -7549,9 +7295,9 @@
       "peer": true
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -7614,56 +7360,56 @@
   },
   "dependencies": {
     "@allurereport/aql": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.3.1.tgz",
-      "integrity": "sha512-adPJh1MyHQTJgGbkzb8Gdnx9aACKqL+HEHBLUbT9ltrHOow5fiT2hlHnreKQS0gPaeCmXZ5Aza21I5hezaKmnA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.4.0.tgz",
+      "integrity": "sha512-hMA0hJPyYilDrfzXMWDa/oyV8ODeexYoEmTp0FpAM/nl4hb+6ij3yy2DcmmM4+GORnq1H+bPeXStoN0sZchCTQ=="
     },
     "@allurereport/charts-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.3.1.tgz",
-      "integrity": "sha512-YZT9D4Nn2NZDK2NQxaVWeiwVDwiZSiBy/g7HRftTMfnl2cWs5tHN4AcU6SrVXPQ6BmcKqvYRetg6kXRzt3o9GA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.4.0.tgz",
+      "integrity": "sha512-tl664OVLhV3g4ZIJnzwbm+MKc26qCdXLQWADU+9LQhTWDJcJ9piu7dANqgSll3Gbf4eRd+1tcsCvUH3Bl5xMRg==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "d3-shape": "^3.2.0"
       }
     },
     "@allurereport/ci": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.3.1.tgz",
-      "integrity": "sha512-Hi+eo1X8ZFyFqW5+SEsGz971E6oNsyHWHZ/JsUt6qxxNtYXYVIvAWCef/Kg6nAsfj1FqjbIsYOz+QZ8N602BRw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.4.0.tgz",
+      "integrity": "sha512-HoJGp+UNgbYbtcQYMcwnK6tMfdEgsqqzW8Vo8eT67ZJfB/JBiT8rCkH9idZePHTvFOvkovdrEfu+encBn5rerQ==",
       "requires": {
-        "@allurereport/core-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0"
       }
     },
     "@allurereport/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-JJJ8uQ3gr1RrmzPSFaY/Y5aQ9QSE5xfBP2TTmKs6dHMpPJhhI11BkAdK4jekjqxba2iBPxeh6oGbeMQgBlhk/w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-rL3HI5fBx6cPwtogss2U3olWLC05aqWPrc/4pCAQXx4lMyO4pgSW+gWiY1HOUxq/TVtH9vw8U+DUxCdTb24u4Q==",
       "requires": {
-        "@allurereport/ci": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-allure2": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/plugin-awesome": "3.3.1",
-        "@allurereport/plugin-classic": "3.3.1",
-        "@allurereport/plugin-csv": "3.3.1",
-        "@allurereport/plugin-dashboard": "3.3.1",
-        "@allurereport/plugin-jira": "3.3.1",
-        "@allurereport/plugin-log": "3.3.1",
-        "@allurereport/plugin-progress": "3.3.1",
-        "@allurereport/plugin-slack": "3.3.1",
-        "@allurereport/plugin-testops": "3.3.1",
-        "@allurereport/plugin-testplan": "3.3.1",
-        "@allurereport/reader": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
-        "@allurereport/service": "3.3.1",
-        "@allurereport/summary": "3.3.1",
-        "handlebars": "^4.7.8",
+        "@allurereport/ci": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-allure2": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/plugin-awesome": "3.4.0",
+        "@allurereport/plugin-classic": "3.4.0",
+        "@allurereport/plugin-csv": "3.4.0",
+        "@allurereport/plugin-dashboard": "3.4.0",
+        "@allurereport/plugin-jira": "3.4.0",
+        "@allurereport/plugin-log": "3.4.0",
+        "@allurereport/plugin-progress": "3.4.0",
+        "@allurereport/plugin-slack": "3.4.0",
+        "@allurereport/plugin-testops": "3.4.0",
+        "@allurereport/plugin-testplan": "3.4.0",
+        "@allurereport/reader": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
+        "@allurereport/service": "3.4.0",
+        "@allurereport/summary": "3.4.0",
+        "handlebars": "^4.7.9",
         "node-stream-zip": "^1.15.0",
         "p-limit": "^7.2.0",
         "progress": "^2.0.3",
-        "yaml": "^2.8.1",
+        "yaml": "^2.8.3",
         "yoctocolors": "^2.1.1",
         "zip-stream": "^7.0.2"
       },
@@ -7684,155 +7430,196 @@
       }
     },
     "@allurereport/core-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.3.1.tgz",
-      "integrity": "sha512-BM+r1k4fYSIb4iE0H0BK7A79QMG7cp7u2+INk0XGJBdYNwHxqR3y3UIjL33VMABO9bIvuwykm7G3vL822GOedQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.4.0.tgz",
+      "integrity": "sha512-DQpMYOzrhGpM0v1JKNesQK9CFvdkfKyew/VZ4INe9df+xw0fKB+k4pta4XH7XnFcLSFyZCCDZuoiOoP/tdrWUg==",
       "requires": {
         "d3-shape": "^3.2.0"
       }
     },
     "@allurereport/directory-watcher": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.3.1.tgz",
-      "integrity": "sha512-j2pt0WY12w50wVMe1af9ca4N8FTI1+CjxSS+cIekFYbFCk4RLLM8eK8Y9ZPvSm5DOd4nFHBJiF6Dzcpwo98mKQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.4.0.tgz",
+      "integrity": "sha512-knY4pvmCKzJ+FkZqgsovwPBxQPcaoHePwEKta9GvvzDVZDB0zM1e8PlSVlie1OuuIknqHW7W+JClK8jbmy3UUw==",
       "requires": {
         "chokidar": "^4.0.3"
       }
     },
     "@allurereport/plugin-allure2": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.3.1.tgz",
-      "integrity": "sha512-6BCGKILarxQxhIFQVVOSpaxcgfEfmTuOuSI5BBlW/rrUg/rQcVeCEZcWre4/jRUh7ReUpKznbPBOtf1Al/ZJRw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.4.0.tgz",
+      "integrity": "sha512-5ojSo8O4zbzuoMTCvw+v8ooeW8RG+dzBbwtbvbOTL/qf10e9qaRddXT4oUPu9gOOBELCGwv2CwflyZtokXfGpg==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-allure2": "3.3.1",
-        "handlebars": "^4.7.8"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "find-up": "^8.0.0",
+        "handlebars": "^4.7.9"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
+          "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
+          "requires": {
+            "locate-path": "^8.0.0",
+            "unicorn-magic": "^0.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
+          "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
+          "requires": {
+            "p-locate": "^6.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+          "requires": {
+            "yocto-queue": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+          "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+          "requires": {
+            "p-limit": "^4.0.0"
+          }
+        },
+        "yocto-queue": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+          "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="
+        }
       }
     },
     "@allurereport/plugin-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.3.1.tgz",
-      "integrity": "sha512-S5GxaqwiJRnb0Iq8ieTWaNh/aFtUJn5Gcv8zhgsZRHVtCB5CBGDUsHmnTYT494pjUDqbWW4TbnprwvjxC+2sXA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.4.0.tgz",
+      "integrity": "sha512-KGMhnVprTDoqX1a5V1IsLB5Zw8AomY4TWO7hcceODzlPoXnXauWRouqJmol+0X2tQePxQtDH9m0Bs8eZsAqX5A==",
       "requires": {
-        "@allurereport/core-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0"
       }
     },
     "@allurereport/plugin-awesome": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.3.1.tgz",
-      "integrity": "sha512-QJuzVJLhaGbbmDuma8+VkEdKuYNhv17ya1mY86h1jHVDTjZPT3tvC+Qvq72xEuTVEXBmJ1yxXI8nwc2bkWj+kw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.4.0.tgz",
+      "integrity": "sha512-Y5tjzD1otHIeXBxWBpkG/lfuPzsWa4D00P1W/1wmjpp21djUdm+pSDBH/XAX0CRNxhpRwFmRvBym9tVhi6TB6Q==",
       "requires": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-awesome": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-awesome": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
         "d3-shape": "^3.2.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "markdown-it": "^14.1.0"
       }
     },
     "@allurereport/plugin-classic": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.3.1.tgz",
-      "integrity": "sha512-GEtrqGWRFCL1hWzrzVMWN6OcR013S5OKBt2IR+A1txUsWJUzRDOyJx+MXHgarohshz50Ft3DzwiH+fXl0nVRdQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.4.0.tgz",
+      "integrity": "sha512-lIIwEHwsha8iuRWIU/iHZ4k4q3jwCsaDrKYjwbqGW2LIkdu5g4EsmS9tn98lhZRx9lHjt3J/12mY+Uz9mn2UAQ==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-awesome": "3.3.1",
-        "@allurereport/web-classic": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-awesome": "3.4.0",
+        "@allurereport/web-classic": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
         "d3-shape": "^3.2.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "markdown-it": "^14.1.0"
       }
     },
     "@allurereport/plugin-csv": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.3.1.tgz",
-      "integrity": "sha512-PKXnAVabArOrxTQNAKGywFlJV6Ok4wrZlT5q7Lu/LPNTgOVukq61jvVa2qeXnSrbMVhhkmyGOY2MNuuWw8RVCg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.4.0.tgz",
+      "integrity": "sha512-hjmVWL5ulpvS+Fay2Hik44pj0/QfD6ILeh0Spfj44hVgYc8pqSxXe3JGtY163HzqpyTJC8qPhDPX1qbfHh1xng==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0"
       }
     },
     "@allurereport/plugin-dashboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.3.1.tgz",
-      "integrity": "sha512-DW7B2FemB4WKaawFt+jba+UHUGb91I8YVPwAqKsNPPquI5G0zjbok/7t2XrKnEIisyq3UOEw2bLUPF15msrYQQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.4.0.tgz",
+      "integrity": "sha512-xWc6U2/KWYOW+MmkbE+Guz6iBZTGM3ogp+YyZ67D+VsmZwLgkdKp4vEREqj0GW3dXnci278XT79drBFDMmlXTQ==",
       "requires": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-dashboard": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-dashboard": "3.4.0",
         "d3-shape": "^3.2.0",
-        "handlebars": "^4.7.8"
+        "handlebars": "^4.7.9"
       }
     },
     "@allurereport/plugin-jira": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.3.1.tgz",
-      "integrity": "sha512-2Kf9YQcg+M0ONMZeUk+XKj3dtEoezVdd6kIMUBfTxChje6eA6yfOl/pvgOx+ZQWn41U6N+WQHDvK9CaS29lL8w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.4.0.tgz",
+      "integrity": "sha512-PRZ7goz7F8lQJbNm0D71CmRCk26srhU8WEM5UvAU5tej3OA90Q/6vCKSL+pQ2MqXDVu2mPR+oqX1QcyQ+oyECQ==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "axios": "^1.13.5"
       }
     },
     "@allurereport/plugin-log": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.3.1.tgz",
-      "integrity": "sha512-rSR5dt0ofJ2o26WrH1gcOXYP1gT0YbeZTC3OMGHD2jF74iblp+fzGD7duPBXhipttQS3/LUCrE7WFUknwHD7Ww==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.4.0.tgz",
+      "integrity": "sha512-lSL409x4OhtckhOBjJYY1HBlO0puJiSMNG4zCpnTsvIP+vo05niFiIPGr6wGKe14dmfcTF+YQRfPi6Nqhg8s4w==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "yoctocolors": "^2.1.1"
       }
     },
     "@allurereport/plugin-progress": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.3.1.tgz",
-      "integrity": "sha512-UgiAKx2csc1Kxuj5nS2m6MngdA/i76MecwdNvP22K4ZYOhdpdzft4sdbepcL2mTUp0T7NHJv9mYeHzUaVMrMDA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.4.0.tgz",
+      "integrity": "sha512-3mIHQPl1UzALexeoRM03BSQ4BqEz1bIkE8r+LY2rrXSBrYNmsMWsKSl7fMq65BDusNDGO/IJVplkj9yrSGD+cw==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "yoctocolors": "^2.1.1"
       }
     },
     "@allurereport/plugin-server-reload": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.3.1.tgz",
-      "integrity": "sha512-VocgkXf0Cm7NQ5MfwJ+OK98nE5PfsDz8ZjB+hwfHL4JP2DBRlmoStv46E3UpxWbPGR4lRyllqOxVuhMFFiX4ig==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.4.0.tgz",
+      "integrity": "sha512-/R6AsKGmLx7SEXGC2zZ9aa6rC+aZ3LecXjn3q1F2Q7PTWbRopEhDZBhnHWA5OpMEbyZPHIC3S8OKExL+57ntUg==",
       "requires": {
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/static-server": "3.3.1"
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/static-server": "3.4.0"
       }
     },
     "@allurereport/plugin-slack": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.3.1.tgz",
-      "integrity": "sha512-hacNNuhkwzKNYzXE2/Noi4fpden+h7P4+E9y0vpEFuOV7lYr8pbyjayw+Qt5IdY3NxHwD7kKKjLHOAhm0MBYlA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.4.0.tgz",
+      "integrity": "sha512-Y71EddWkOV1G3VxZPj2ai/EiDPSE2NJgjzov8FWLu59+HLFWCUQLj1y7nW3ZKZlvQVD9N4VvKr4pAxqeq7T8iw==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0"
       }
     },
     "@allurereport/plugin-testops": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.3.1.tgz",
-      "integrity": "sha512-6+yO7tpmeXt2hzHlrdRCMF1PEkwKbb54mTXe9TxlJAXxYDYm8lT8Tn6GhwKv3ykmWPPLeuNWvi1mpNC9uj3ABQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.4.0.tgz",
+      "integrity": "sha512-KcJJmCt3UU2PeswKhvOHvtmWHQOOYsgCNM7H6e3PCQ0IX2Yb7uv82T7y2Qpf5TY5RsJ0p3BjimDWc4uWSshlNg==",
       "requires": {
-        "@allurereport/ci": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
+        "@allurereport/ci": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
         "axios": "^1.13.5",
         "form-data": "^4.0.5",
-        "lodash.chunk": "^4.2.0",
+        "lodash-es": "^4",
         "p-limit": "^7.3.0",
-        "progress": "^2.0.3"
+        "progress": "^2.0.3",
+        "yoctocolors": "^2"
       },
       "dependencies": {
         "p-limit": {
@@ -7851,123 +7638,76 @@
       }
     },
     "@allurereport/plugin-testplan": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.3.1.tgz",
-      "integrity": "sha512-Hz2972TjHD5Fpa4yuDkQpAZZA9l883xHkBvcHNVkH2e0ymwfINX/HTfbBr0CsgfJLOa3Sfgr255MdaBc8JEt4A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.4.0.tgz",
+      "integrity": "sha512-EcY+go2R+twHYrUsHJGsxUEg/J0HwiAvLTNClxBMllvXfwsNTVLu5p24NlteAhRUTFdYGoAnN1cw4s7s37DEbA==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0"
       }
     },
     "@allurereport/reader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.3.1.tgz",
-      "integrity": "sha512-T6sGcwxo8+5tJBJFvbd9eSJGgQ8WNyk34LEHRrVV9KAsiBIz92WvLObV7jH1rbodVoWFbxZ6AZkzgoCwcfLchQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.4.0.tgz",
+      "integrity": "sha512-0RZhijmKAZAqYzrzWV5BPOu7b6p/UXyuRw+cuAw2Va1vu0I1I0ZuZvxQHaHV+I9TUmzpEP6mPx+JVttI5v35Dg==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
-        "fast-xml-parser": "^5.3.6"
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
+        "fast-xml-parser": "^5.5.7"
       }
     },
     "@allurereport/reader-api": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.3.1.tgz",
-      "integrity": "sha512-Fbew7o4IkFrgifUEfWkxgR6KFnthmMxGVCz8CyQTUGciZJ/rixzwgvBH2rtSaoBiH4cWdjT52+q0aQHlX+1Tgg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.4.0.tgz",
+      "integrity": "sha512-HhBN48/frcJ4u27UmUFWCPGfVDauJ+8zNbIyME5RLnHSBAOVuV81DDMgp6EOQ3ETuo/+6GzvgY/oRZ+oc750bg==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "mime-types": "^2.1.35"
       }
     },
     "@allurereport/service": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.3.1.tgz",
-      "integrity": "sha512-OjOYszEslSGs2grMcgUcG6C1UANySG9Y5t29bH01ZjGcNTb8v+PQe3Hg1U0GXmhvWFaMfrNMRGNlcbhoDaEvEw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.4.0.tgz",
+      "integrity": "sha512-tjMLo3MVWJrRluxaSFmbVgcxJvJWwgxXn86//2aU0MVUTDKXb47bXEYdJAcBAEpyk8q2yJObg11HUeZyk41aNw==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "axios": "^1.13.5",
         "open": "^10.1.0"
       }
     },
     "@allurereport/static-server": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.3.1.tgz",
-      "integrity": "sha512-rsVkM8zAMDCHizRP6ldNhlasrrzZnhokosFTcwszhedlf67aGtSLF+xtuwZUd8m0a/r2n+1bNSEDJhpB8Aoi/g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.4.0.tgz",
+      "integrity": "sha512-S+mT7NG62f7XMVjleoL3ATICBgpWT3npZnDndb8FXhXyKGUy4PCke/vs6hdO1WBKAO0Fd+AwZKv9/PxSa0uHJA==",
       "requires": {
-        "@allurereport/directory-watcher": "3.3.1",
+        "@allurereport/directory-watcher": "3.4.0",
         "open": "^10.1.0"
       }
     },
     "@allurereport/summary": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.3.1.tgz",
-      "integrity": "sha512-W7sMyqKAhJOyDm0Ktza5OAjGW9OAPv3/gwLQPwSeIJWrCnrlwb8jeE3dTd+GNP7s6Swx4jFJAfxxcs4N37k3Wg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.4.0.tgz",
+      "integrity": "sha512-/9Pj0SwOicDyKvmE2//Dhq+u9834j2i3JJQRlhi81Pf79VWPdekxBAT+g58E0T5OOvVfeKLttGYo7v9n/OEwKA==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-summary": "3.3.1",
-        "handlebars": "^4.7.8"
-      }
-    },
-    "@allurereport/web-allure2": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-allure2/-/web-allure2-3.3.1.tgz",
-      "integrity": "sha512-MMcVVwqIY7X2nsI/7JvQlal4GtqPe2yVm37kqOkvt9X6rjLpq4tXTgHwceEEKIbzOmgvLGk6M9hzMJGkgOgBjw==",
-      "requires": {
-        "@allurereport/web-commons": "3.3.1",
-        "@babel/runtime": "^7.27.6",
-        "b_": "^1.3.4",
-        "backbone": "^1.6.0",
-        "backbone.marionette": "^3.5.1",
-        "d3-array": "^3.2.4",
-        "d3-axis": "^3.0.0",
-        "d3-brush": "^3.0.0",
-        "d3-drag": "^3.0.0",
-        "d3-dsv": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.1.0",
-        "d3-selection": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "filesize": "^10.1.6",
-        "handlebars": "^4.7.8",
-        "highlight.js": "^10.7.3",
-        "i18next": "^8.4.3",
-        "jquery": "^3.7.1",
-        "postcss": "^8.5.6",
-        "sortablejs": "^1.15.3",
-        "split.js": "^1.6.5",
-        "underscore": "^1.13.7",
-        "url": "^0.11.4"
-      },
-      "dependencies": {
-        "backbone": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.6.1.tgz",
-          "integrity": "sha512-YQzWxOrIgL6BoFnZjThVN99smKYhyEXXFyJJ2lsF1wJLyo4t+QjmkLrH8/fN22FZ4ykF70Xq7PgTugJVR4zS9Q==",
-          "requires": {
-            "underscore": ">=1.8.3"
-          }
-        },
-        "underscore": {
-          "version": "1.13.8",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-          "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
-        }
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-summary": "3.4.0",
+        "handlebars": "^4.7.9"
       }
     },
     "@allurereport/web-awesome": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.3.1.tgz",
-      "integrity": "sha512-tf8PVcRKY33pVRcNGvFBAbwa0VH/YZwZ7cA/4ytdLGH4TW6bHQ4HNR9yp+LWpwUvl+ONXjKExc0wxJV/AtSjjQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.4.0.tgz",
+      "integrity": "sha512-FsyvWnNzRhSI/jda2zuO+TLaefWorKDDn6IX2bK2eRhlqzgbVnwTpHwH/InnG0/5QXBVi7KWNZnkSh9zbP95SQ==",
       "requires": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "d3-shape": "^3.2.0",
@@ -7975,27 +7715,17 @@
         "md5": "^2.3.0",
         "preact": "^10.28.2",
         "prismjs": "^1.30.0"
-      },
-      "dependencies": {
-        "i18next": {
-          "version": "24.2.3",
-          "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-          "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-          "requires": {
-            "@babel/runtime": "^7.26.10"
-          }
-        }
       }
     },
     "@allurereport/web-classic": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.3.1.tgz",
-      "integrity": "sha512-SthPjBwZYgqzEFB9IvjCYdJk3WQee1iN71WDSVj3v9COcp7icXJMPW+7uc8Z63TNLWYgoHZ7Xm4DMYoabb2wcw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.4.0.tgz",
+      "integrity": "sha512-8q98s9U6a2fHYoksIfWYdKkoRvsZRvLriqj34fGkOWag4dq6tbDi+jK6F4/3FCfZCbs5M62GuiHnnx1YkPbYcg==",
       "requires": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "d3-shape": "^3.2.0",
@@ -8004,44 +7734,34 @@
         "preact": "^10.28.2",
         "prismjs": "^1.30.0",
         "split.js": "^1.6.5"
-      },
-      "dependencies": {
-        "i18next": {
-          "version": "24.2.3",
-          "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-          "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-          "requires": {
-            "@babel/runtime": "^7.26.10"
-          }
-        }
       }
     },
     "@allurereport/web-commons": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.3.1.tgz",
-      "integrity": "sha512-ZlO4H4TEvnAKLRWxusGW4+ahnm2MwjCOBd7LwL+gf7PfE0JmHXDFatMr6b4Kix0RgsDvpay9qPQ6LtUm4bKYbA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.4.0.tgz",
+      "integrity": "sha512-Jo7cbvoDwWq/herqCCjsKdOQKXKx6nnBuP+R6AWcePU0evmlXMSNUA/a9QvgFkI6gucIsxbKDa5GG01+mo5gEg==",
       "requires": {
-        "@allurereport/aql": "3.3.1",
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
+        "@allurereport/aql": "3.4.0",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
         "@preact/signals": "^2.6.1",
         "@preact/signals-core": "^1.12.2",
         "ansi-to-html": "^0.7.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-shape": "^3.2.0",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.3.2",
         "nanoid": "^5.1.6"
       }
     },
     "@allurereport/web-components": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.3.1.tgz",
-      "integrity": "sha512-oxHR671VqmA5h/KZZmqYufZa3dBAYDo6gVs8phkgDI04GnmBUSo38rIRuwnvYyHAuueV4wsA05vQxn8BJTDM8g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.4.0.tgz",
+      "integrity": "sha512-3Pzp04ZS6xfnh3D8TRpMZ2RSukWrHYxUr+vnYAzNVs7jU9L/PrV5H2HGD+5ssYay9it3JQ306qRkdOpWDFkQwg==",
       "requires": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
         "@floating-ui/dom": "^1.7.4",
         "@nivo/bar": "^0.99.0",
         "@nivo/core": "^0.99.0",
@@ -8078,52 +7798,32 @@
       }
     },
     "@allurereport/web-dashboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.3.1.tgz",
-      "integrity": "sha512-APX7W4xnNK6bImuVUwPOUIrC0Y0N3ertIUgkFBy8+mzuenxCBI1e9oJOyqiZna5GNz9kKsYMhBNwgza2LCKuFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.4.0.tgz",
+      "integrity": "sha512-smPiLsYP96xOe98XuFiT20NRF4ublc8ADOgGGOTACPluDok/40VI0XUwDV4rORvpSXIvOxNvoTtqz8yGA4ycnw==",
       "requires": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "i18next": "^24.0.2",
         "preact": "^10.28.2"
-      },
-      "dependencies": {
-        "i18next": {
-          "version": "24.2.3",
-          "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-          "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-          "requires": {
-            "@babel/runtime": "^7.26.10"
-          }
-        }
       }
     },
     "@allurereport/web-summary": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.3.1.tgz",
-      "integrity": "sha512-R+YL2tjgQoyNs3qO85ZY3VdHXoN3CPDkU/lxUd60rGhvvIK7UDTMgHmCbU/ttW/O5hkR+qVXrrG22c3aMmR3oQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.4.0.tgz",
+      "integrity": "sha512-1jBiKCnxjJP4nzUUGWRtoCKkpdtNxhDMMu5FcfKB6fJsI3lvIQfO+qlcg3ln0Vx7B6MHlY/5VmvOtVvTbUCkQg==",
       "requires": {
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/web-commons": "3.3.1",
-        "@allurereport/web-components": "3.3.1",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/web-commons": "3.4.0",
+        "@allurereport/web-components": "3.4.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "i18next": "^24.0.2",
         "preact": "^10.28.2"
-      },
-      "dependencies": {
-        "i18next": {
-          "version": "24.2.3",
-          "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
-          "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
-          "requires": {
-            "@babel/runtime": "^7.26.10"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -9045,9 +8745,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
     },
     "@babel/template": {
       "version": "7.27.2",
@@ -9188,26 +8888,26 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="
     },
     "@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "requires": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "requires": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
     "@isaacs/cliui": {
       "version": "9.0.0",
@@ -9562,17 +9262,17 @@
       "requires": {}
     },
     "@preact/signals": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.8.1.tgz",
-      "integrity": "sha512-wX6U0SpcCukZTJBs5ChljvBZb3XmYzA5gd4vKHgX8wZZKaQCo2WHtmThdLx+mcVvlBa5u3XShC7ffbETJD4BiQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.0.tgz",
+      "integrity": "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==",
       "requires": {
-        "@preact/signals-core": "^1.13.0"
+        "@preact/signals-core": "^1.14.0"
       }
     },
     "@preact/signals-core": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
-      "integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng=="
     },
     "@qavajs/cypress": {
       "version": "2.8.0",
@@ -9580,27 +9280,14 @@
       "integrity": "sha512-PKMuuz3rdO/McGhLsEef7Ewcd+eDWShEOqzo+z5Qk2dVLeG2JveflSEuFJQx6s7xhAc/dbowXWbaf5NrINbjzQ=="
     },
     "@qavajs/cypress-runner-adapter": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@qavajs/cypress-runner-adapter/-/cypress-runner-adapter-1.9.0.tgz",
-      "integrity": "sha512-5MHvGzN4Z2j8zAUOF7ByHD/IN34hi5bnOcEDQTuIaWFG0k9X9SPabPS+4Di1TwMWvZE95sRwk3eW4iry3NgPWA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@qavajs/cypress-runner-adapter/-/cypress-runner-adapter-1.9.1.tgz",
+      "integrity": "sha512-2GrT+Dpm4n51f8XBHBR0GKpbHCooRfzQbT8pQmpgNIbigceKmPJkLddJ9MmsQDsfKGvro+YK+OgHfQ8k8ysLew==",
       "requires": {
         "@cucumber/cucumber-expressions": "^19.0.0",
         "@cucumber/gherkin": "^39.0.0",
         "@cucumber/tag-expressions": "^9.1.0",
-        "@cypress/webpack-preprocessor": "^7.0.2",
-        "fs-extra": "^11.3.4"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.3.4",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-          "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
+        "@cypress/webpack-preprocessor": "^7.0.2"
       }
     },
     "@qavajs/memory": {
@@ -10015,29 +9702,29 @@
       }
     },
     "allure": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/allure/-/allure-3.3.1.tgz",
-      "integrity": "sha512-wH2ZiJil1wzhbHN9jLkxXM/PLw2pxjTIzV/lDSyIHUGNYsDQb1cioE7eJRNDTL5cYTeoPpJL1IhsBfKFE2R8ZA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/allure/-/allure-3.4.0.tgz",
+      "integrity": "sha512-MeU2BuMJt+M94qXS03RCgzDIw+gU8H8Yxl4840vgBi+EDSpcCcl/U3CslxOw9Y/fwte74yqQZu5oRa2hkCwEdA==",
       "requires": {
-        "@allurereport/charts-api": "3.3.1",
-        "@allurereport/ci": "3.3.1",
-        "@allurereport/core": "3.3.1",
-        "@allurereport/core-api": "3.3.1",
-        "@allurereport/directory-watcher": "3.3.1",
-        "@allurereport/plugin-allure2": "3.3.1",
-        "@allurereport/plugin-api": "3.3.1",
-        "@allurereport/plugin-awesome": "3.3.1",
-        "@allurereport/plugin-classic": "3.3.1",
-        "@allurereport/plugin-csv": "3.3.1",
-        "@allurereport/plugin-dashboard": "3.3.1",
-        "@allurereport/plugin-jira": "3.3.1",
-        "@allurereport/plugin-log": "3.3.1",
-        "@allurereport/plugin-progress": "3.3.1",
-        "@allurereport/plugin-server-reload": "3.3.1",
-        "@allurereport/plugin-slack": "3.3.1",
-        "@allurereport/reader-api": "3.3.1",
-        "@allurereport/service": "3.3.1",
-        "@allurereport/static-server": "3.3.1",
+        "@allurereport/charts-api": "3.4.0",
+        "@allurereport/ci": "3.4.0",
+        "@allurereport/core": "3.4.0",
+        "@allurereport/core-api": "3.4.0",
+        "@allurereport/directory-watcher": "3.4.0",
+        "@allurereport/plugin-allure2": "3.4.0",
+        "@allurereport/plugin-api": "3.4.0",
+        "@allurereport/plugin-awesome": "3.4.0",
+        "@allurereport/plugin-classic": "3.4.0",
+        "@allurereport/plugin-csv": "3.4.0",
+        "@allurereport/plugin-dashboard": "3.4.0",
+        "@allurereport/plugin-jira": "3.4.0",
+        "@allurereport/plugin-log": "3.4.0",
+        "@allurereport/plugin-progress": "3.4.0",
+        "@allurereport/plugin-server-reload": "3.4.0",
+        "@allurereport/plugin-slack": "3.4.0",
+        "@allurereport/reader-api": "3.4.0",
+        "@allurereport/service": "3.4.0",
+        "@allurereport/static-server": "3.4.0",
         "adm-zip": "^0.5.16",
         "clipanion": "^4.0.0-rc.4",
         "glob": "^11.1.0",
@@ -10048,17 +9735,17 @@
       }
     },
     "allure-cypress": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/allure-cypress/-/allure-cypress-3.6.0.tgz",
-      "integrity": "sha512-a6t8v9B2K/Pn8ROeOzMbua5yd9HKy4VXfzxiiBB6hYYZPndaWrcE/v/obZIMBi5tCDnMDbWGfcwjTPKUI0+azQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/allure-cypress/-/allure-cypress-3.7.0.tgz",
+      "integrity": "sha512-z2D6CJGC0Z8SEg56FgZbDmsASn+C43qoAd2rNEm1dKn0DL3AbEJghRZKuzNr0OmPwZUll9y7QVcuRfs1oq6RRg==",
       "requires": {
-        "allure-js-commons": "3.6.0"
+        "allure-js-commons": "3.7.0"
       }
     },
     "allure-js-commons": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.6.0.tgz",
-      "integrity": "sha512-RquIzMlh2l+ZLtq+Uxt+ZpOptxLzyPvLfPGbwU7dtgXo0QfUvhLFFkCljIR7Gjxo7jZ+WVqoto1yOPpXqU/i4g==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.7.0.tgz",
+      "integrity": "sha512-cDjqmSIDhpk0AFktb7/qwAk4D3To8S0bmPROq0hS5dDby+uXf6ir4WyXI0HC/rHS9+smidyFHwBod3yIQ8kZ4w==",
       "requires": {
         "md5": "^2.3.0"
       }
@@ -10146,26 +9833,21 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
     "axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "requires": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       },
       "dependencies": {
         "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+          "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
         }
       }
-    },
-    "b_": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/b_/-/b_-1.3.4.tgz",
-      "integrity": "sha512-IYgNQdGx8RgDMYXMF1L2KC+HHHBD4FuIqkGBBPDd+KiGTy/1eWrNlZnvfQh0RZGcDglmSus2eqb3ISW0nvYHsg=="
     },
     "babel-loader": {
       "version": "10.0.0",
@@ -10206,29 +9888,6 @@
         "@babel/helper-define-polyfill-provider": "^0.6.5"
       }
     },
-    "backbone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
-      "integrity": "sha512-aK+k3TiU4tQDUrRCymDDE7XDFnMVuyE6zbZ4JX7mb4pJbQTVOH997/kyBzb8wB2s5Y/Oh7EUfj+sZhwRPxWwow==",
-      "peer": true,
-      "requires": {
-        "underscore": ">=1.8.3"
-      }
-    },
-    "backbone.marionette": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-3.5.1.tgz",
-      "integrity": "sha512-1eegQCV+Bn+G7uXRkN3llajwxW+2dPGrMy189+S0UUJjN1vDhCZBBMwwhzVhpGX5vKTzM/q6rOEYAbJxvOkVXA==",
-      "requires": {
-        "backbone.radio": "^2.0.0"
-      }
-    },
-    "backbone.radio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/backbone.radio/-/backbone.radio-2.0.0.tgz",
-      "integrity": "sha512-SHdSh2OaWqalbYi1sXvbTtnRFym5AV9loybNi2Q1iHkU2vveQDlWsmDn9l8onmfR6ZkemuYgHLgtfAYKfyfBZg==",
-      "requires": {}
-    },
     "balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -10264,9 +9923,9 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "requires": {
         "balanced-match": "^4.0.2"
       }
@@ -10558,9 +10217,9 @@
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "cypress": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.11.0.tgz",
-      "integrity": "sha512-NXDE6/fqZuzh1Zr53nyhCCa4lcANNTYWQNP9fJO+tzD3qVTDaTUni5xXMuigYjMujQ7CRiT9RkJJONmPQSsDFw==",
+      "version": "15.13.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
+      "integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
       "requires": {
         "@cypress/request": "^3.0.10",
         "@cypress/xvfb": "^1.2.4",
@@ -10669,23 +10328,6 @@
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
-      }
-    },
-    "d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "requires": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        }
       }
     },
     "d3-ease": {
@@ -10852,9 +10494,9 @@
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="
     },
     "delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
       "requires": {
         "robust-predicates": "^3.0.2"
       }
@@ -10865,9 +10507,9 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "requires": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -11091,17 +10733,21 @@
       "peer": true
     },
     "fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "requires": {
+        "path-expression-matcher": "^1.1.3"
+      }
     },
     "fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
+      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
       "requires": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.4.0",
+        "strnum": "^2.2.3"
       }
     },
     "fd-slicer": {
@@ -11119,11 +10765,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
-    },
-    "filesize": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
-      "integrity": "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w=="
     },
     "find-up": {
       "version": "5.0.0",
@@ -11275,9 +10916,9 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -11328,11 +10969,6 @@
         "function-bind": "^1.1.2"
       }
     },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
-    },
     "http-signature": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
@@ -11349,16 +10985,11 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "i18next": {
-      "version": "8.4.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-8.4.3.tgz",
-      "integrity": "sha512-V6HKLWSh2d/CSie1s/TErgEIdu/gPRUGJo/kBRcOW+YH2fnwMl3ByIMGsKSO5qajThceQ9AghZQ+OsGVS492/g=="
-    },
-    "iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "@babel/runtime": "^7.26.10"
       }
     },
     "ieee754": {
@@ -11479,11 +11110,6 @@
         "supports-color": "^8.0.0"
       }
     },
-    "jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11593,14 +11219,14 @@
       }
     },
     "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
-    "lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w=="
+    "lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -11756,9 +11382,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
-      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -11863,6 +11489,11 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "peer": true
     },
+    "path-expression-matcher": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
+      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q=="
+    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -11903,34 +11534,18 @@
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "peer": true
     },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
-    "postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "requires": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "3.3.11",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-          "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
-        }
-      }
-    },
     "preact": {
-      "version": "10.28.4",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
-      "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ=="
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="
     },
     "pretty-bytes": {
       "version": "5.6.0",
@@ -11974,11 +11589,6 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "punycode.js": {
       "version": "2.3.1",
@@ -12141,19 +11751,14 @@
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="
     },
     "run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="
-    },
-    "rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "rxjs": {
       "version": "7.8.1",
@@ -12278,11 +11883,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
-    "source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
-    },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -12346,9 +11946,9 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="
     },
     "supports-color": {
       "version": "8.1.1",
@@ -12487,12 +12087,6 @@
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "optional": true
     },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
-      "peer": true
-    },
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -12526,6 +12120,11 @@
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
       "peer": true
     },
+    "unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
+    },
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -12546,19 +12145,10 @@
         "picocolors": "^1.1.1"
       }
     },
-    "url": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-      "requires": {
-        "punycode": "^1.4.1",
-        "qs": "^6.12.3"
-      }
-    },
     "use-debounce": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
-      "integrity": "sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
       "requires": {}
     },
     "uuid": {
@@ -12668,9 +12258,9 @@
       "peer": true
     },
     "yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -14,11 +14,11 @@
   "license": "MIT",
   "dependencies": {
     "@qavajs/cypress": "^2.8.0",
-    "@qavajs/cypress-runner-adapter": "^1.9.0",
+    "@qavajs/cypress-runner-adapter": "^1.9.1",
     "@qavajs/memory": "^1.10.3",
-    "allure": "^3.3.1",
-    "allure-cypress": "^3.6.0",
+    "allure": "^3.4.0",
+    "allure-cypress": "^3.7.0",
     "cross-env": "^10.1.0",
-    "cypress": "^15.11.0"
+    "cypress": "^15.13.1"
   }
 }

--- a/electron-playwright/package-lock.json
+++ b/electron-playwright/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/cucumber": "^12.6.0",
+        "@cucumber/cucumber": "^12.7.0",
         "@qavajs/console-formatter": "^1.1.1",
         "@qavajs/core": "^2.13.0",
-        "@qavajs/html-formatter": "^1.0.0",
+        "@qavajs/html-formatter": "^1.2.0",
         "@qavajs/memory": "^1.10.3",
-        "@qavajs/steps-playwright": "^2.14.1",
-        "@qavajs/validation": "^1.6.1",
-        "electron": "^40.4.1",
+        "@qavajs/steps-playwright": "^2.15.0",
+        "@qavajs/validation": "^1.6.2",
+        "electron": "^41.2.0",
         "ts-node": "^10.9.2"
       }
     },
@@ -66,28 +66,28 @@
       }
     },
     "node_modules/@cucumber/ci-environment": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-12.0.0.tgz",
-      "integrity": "sha512-SqCEnbCNl3zCXCFpqGUuoaSNhLC0jLw4tKeFcAxTw9MD/QRlJjeAC/fyvVLFuXuSq0OunJlFfxLu+Z3HE+oLPg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-13.0.0.tgz",
+      "integrity": "sha512-cs+3NzfNkGbcmHPddjEv4TKFiBpZRQ6WJEEufB9mw+ExS22V/4R/zpDSEG+fsJ/iSNCd6A2sATdY8PFOyY3YnA==",
       "license": "MIT"
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-12.6.0.tgz",
-      "integrity": "sha512-z6XKBIcUnJebnR3W8+K7Q2jJKB+pKpoD1l3CygEa9ufq/aeGuS5LAlllNxrod8loepLJhNmp8J8aengGbkL4cg==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-12.7.0.tgz",
+      "integrity": "sha512-7A/9CJpJDxv1SQ7hAZU0zPn2yRxx6XMR+LO4T94Enm3cYNWsEEj+RGX38NLX4INT+H6w5raX3Csb/qs4vUBsOA==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/ci-environment": "12.0.0",
-        "@cucumber/cucumber-expressions": "18.1.0",
-        "@cucumber/gherkin": "37.0.1",
+        "@cucumber/ci-environment": "13.0.0",
+        "@cucumber/cucumber-expressions": "19.0.0",
+        "@cucumber/gherkin": "38.0.0",
         "@cucumber/gherkin-streams": "6.0.0",
-        "@cucumber/gherkin-utils": "10.0.0",
-        "@cucumber/html-formatter": "22.3.0",
+        "@cucumber/gherkin-utils": "11.0.0",
+        "@cucumber/html-formatter": "23.0.0",
         "@cucumber/junit-xml-formatter": "0.9.0",
         "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "31.2.0",
+        "@cucumber/messages": "32.0.1",
         "@cucumber/pretty-formatter": "1.0.1",
-        "@cucumber/tag-expressions": "8.1.0",
+        "@cucumber/tag-expressions": "9.1.0",
         "assertion-error-formatter": "^3.0.0",
         "capital-case": "^1.0.4",
         "chalk": "^4.1.2",
@@ -110,7 +110,7 @@
         "mz": "^2.7.0",
         "progress": "^2.0.3",
         "read-package-up": "^12.0.0",
-        "semver": "7.7.3",
+        "semver": "7.7.4",
         "string-argv": "0.3.1",
         "supports-color": "^8.1.1",
         "type-fest": "^4.41.0",
@@ -129,21 +129,21 @@
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.1.0.tgz",
-      "integrity": "sha512-9yc+wForrn15FaqLWNjYb19iQ/gPXhcq1kc4X1Ex1lR7NcJpa5pGnCow3bc1HERVM5IoYH+gwwrcJogSMsf+Vw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-19.0.0.tgz",
+      "integrity": "sha512-4FKoOQh2Uf6F6/Ln+1OxuK8LkTg6PyAqekhf2Ix8zqV2M54sH+m7XNJNLhOFOAW/t9nxzRbw2CcvXbCLjcvHZg==",
       "license": "MIT",
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "37.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-37.0.1.tgz",
-      "integrity": "sha512-VmX+PKa9vqKZiycZoQKYlCsA0N7gAfiOfrcHSjK+suEVUwvKEH2sjO47NznrFFLmVWYTRmw3DLHQnpBAznkYEA==",
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-38.0.0.tgz",
+      "integrity": "sha512-duEXK+KDfQUzu3vsSzXjkxQ2tirF5PRsc1Xrts6THKHJO6mjw4RjM8RV+vliuDasmhhrmdLcOcM7d9nurNTJKw==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=31.0.0 <32"
+        "@cucumber/messages": ">=31.0.0 <33"
       }
     },
     "node_modules/@cucumber/gherkin-streams": {
@@ -174,65 +174,34 @@
       }
     },
     "node_modules/@cucumber/gherkin-utils": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-10.0.0.tgz",
-      "integrity": "sha512-BcujlDT343GXXNrMPl3ws6Il3zs8dQw3Yp/d3HnOJF8i2snGGgiapoTbko7MdvAt7ivDL7SDo+e1d5Cnpl3llA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-11.0.0.tgz",
+      "integrity": "sha512-LJ+s4+TepHTgdKWDR4zbPyT7rQjmYIcukTwNbwNwgqr6i8Gjcmzf6NmtbYDA19m1ZFg6kWbFsmHnj37ZuX+kZA==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/gherkin": "^34.0.0",
-        "@cucumber/messages": "^29.0.0",
+        "@cucumber/gherkin": "^38.0.0",
+        "@cucumber/messages": "^32.0.0",
         "@teppeis/multimaps": "3.0.0",
-        "commander": "14.0.0",
+        "commander": "14.0.2",
         "source-map-support": "^0.5.21"
       },
       "bin": {
         "gherkin-utils": "bin/gherkin-utils"
       }
     },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-34.0.0.tgz",
-      "integrity": "sha512-659CCFsrsyvuBi/Eix1fnhSheMnojSfnBcqJ3IMPNawx7JlrNJDcXYSSdxcUw3n/nG05P+ptCjmiZY3i14p+tA==",
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <29"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-28.1.0.tgz",
-      "integrity": "sha512-2LzZtOwYKNlCuNf31ajkrekoy2M4z0Z1QGiPH40n4gf5t8VOUFb7m1ojtR4LmGvZxBGvJZP8voOmRqDWzBzYKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "10.0.0",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "11.1.0"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/messages": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-29.0.1.tgz",
-      "integrity": "sha512-aAvIYfQD6/aBdF8KFQChC3CQ1Q+GX9orlR6GurGiX6oqaCnBkxA4WU3OQUVepDynEFrPayerqKRFcAMhdcXReQ==",
-      "license": "MIT",
-      "dependencies": {
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2"
-      }
-    },
     "node_modules/@cucumber/gherkin-utils/node_modules/commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cucumber/html-formatter": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-22.3.0.tgz",
-      "integrity": "sha512-0s3G7kznCRDiiesQ4K0yBdswGqU9E0j2AWUug41NpedBzhaY+Hn192ANRF597GZtuWrCjE53aFb3fOyOsT8B+g==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-23.0.0.tgz",
+      "integrity": "sha512-WwcRzdM8Ixy4e53j+Frm3fKM5rNuIyWUfy4HajEN+Xk/YcjA6yW0ACGTFDReB++VDZz/iUtwYdTlPRY36NbqJg==",
       "license": "MIT",
       "peerDependencies": {
         "@cucumber/messages": ">=18"
@@ -263,9 +232,9 @@
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "31.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-31.2.0.tgz",
-      "integrity": "sha512-3urzBNCwmU/YKrKR0b3XdioFcOFNuxlLwEImsxeP8rXnweLs+Ky04QURcbKpFom3T6a6v9zVioLCfHUuSQ72pg==",
+      "version": "32.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.0.1.tgz",
+      "integrity": "sha512-1OSoW+GQvFUNAl6tdP2CTBexTXMNJF0094goVUcvugtQeXtJ0K8sCP0xbq7GGoiezs/eJAAOD03+zAPT64orHQ==",
       "license": "MIT",
       "dependencies": {
         "class-transformer": "0.5.1",
@@ -302,9 +271,9 @@
       }
     },
     "node_modules/@cucumber/tag-expressions": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-8.1.0.tgz",
-      "integrity": "sha512-UFeOVUyc711/E7VHjThxMwg3jbGod9TlbM1gxNixX/AGDKg82Eha4cE0tKki3GGUs7uB2NyI+hQAuhB8rL2h5A==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-9.1.0.tgz",
+      "integrity": "sha512-bvHjcRFZ+J1TqIa9eFNO1wGHqwx4V9ZKV3hYgkuK/VahHx73uiP4rKV3JVrvWSMrwrFvJG6C8aEwnCWSvbyFdQ==",
       "license": "MIT"
     },
     "node_modules/@electron/get": {
@@ -335,15 +304,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -430,9 +390,10 @@
       }
     },
     "node_modules/@qavajs/html-formatter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@qavajs/html-formatter/-/html-formatter-1.0.0.tgz",
-      "integrity": "sha512-Ic68ePyDbbwrTRsSCsgMIs4KcbYDeFHYdkfx/egj8ppLH/7KTT/AOqcTfUtRYxCsB66klWdLuTlwdAXq3QEXow=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@qavajs/html-formatter/-/html-formatter-1.2.0.tgz",
+      "integrity": "sha512-+Y4x7OVYonB5m+VpjgPozQXJdQeAYRilfNzaMnhi77ajMq+ck8TuutjraMVe6VPXVGJRNNh2Oa2O6UX5Hm2/Qg==",
+      "license": "MIT"
     },
     "node_modules/@qavajs/memory": {
       "version": "1.10.3",
@@ -441,21 +402,21 @@
       "license": "MIT"
     },
     "node_modules/@qavajs/steps-playwright": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@qavajs/steps-playwright/-/steps-playwright-2.14.1.tgz",
-      "integrity": "sha512-gSQnTSioCKjIx2u4B1q4hr6efgBM3Kfuoyq5Ove9mleVcKkxCOSXORjtDM8pQyhUbcOAqLDYAmu/pqZ0vE8pJw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@qavajs/steps-playwright/-/steps-playwright-2.15.0.tgz",
+      "integrity": "sha512-ghwcZfu8LoqcYmFZcrgKpbtv/+mTJh6/9sVgQTLMxUMPiVVgpCaQIM6iuWEEFQ78MuvJ59dYJIxJOnCmHvfSkg==",
       "license": "MIT",
       "dependencies": {
-        "@playwright/test": "^1.57.0"
+        "@playwright/test": "^1.58.2"
       }
     },
     "node_modules/@qavajs/validation": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@qavajs/validation/-/validation-1.6.1.tgz",
-      "integrity": "sha512-3bh6DHFzWkZl1AcUP5NM6o8+yLk4n04L8FIzbdKN83VDzPzvTEhEcUZEOQf8Qs+YpZhl3fybVC00fvbKpqShFQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@qavajs/validation/-/validation-1.6.2.tgz",
+      "integrity": "sha512-ek4v44rYOOd2LilisJWHIXdumJYYS7Kv67zhqocNo/wyq6QTYtFETiMvZafwa/H1wd3FvFm9bqbp6Nei9cIb0Q==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.17.1"
+        "ajv": "8.18.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -566,12 +527,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -667,15 +622,12 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/boolean": {
@@ -687,15 +639,15 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer-crc32": {
@@ -1042,9 +994,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.4.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.4.1.tgz",
-      "integrity": "sha512-N1ZXybQZL8kYemO8vAeh9nrk4mSvqlAO8xs0QCHkXIvRnuB/7VGwEehjvQbsU5/f4bmTKpG+2GQERe/zmKpudQ==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.2.0.tgz",
+      "integrity": "sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1540,21 +1492,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1715,15 +1652,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2118,9 +2055,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2471,19 +2408,6 @@
       "integrity": "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -2604,9 +2528,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/electron-playwright/package.json
+++ b/electron-playwright/package.json
@@ -19,14 +19,14 @@
   },
   "homepage": "https://github.com/qavajs/demo#readme",
   "dependencies": {
-    "@cucumber/cucumber": "^12.6.0",
+    "@cucumber/cucumber": "^12.7.0",
     "@qavajs/console-formatter": "^1.1.1",
     "@qavajs/core": "^2.13.0",
-    "@qavajs/html-formatter": "^1.0.0",
+    "@qavajs/html-formatter": "^1.2.0",
     "@qavajs/memory": "^1.10.3",
-    "@qavajs/steps-playwright": "^2.14.1",
-    "@qavajs/validation": "^1.6.1",
-    "electron": "^40.4.1",
+    "@qavajs/steps-playwright": "^2.15.0",
+    "@qavajs/validation": "^1.6.2",
+    "electron": "^41.2.0",
     "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
- cypress:
  - upgraded @qavajs/cypress-runner-adapter from ^1.9.0 to ^1.9.1
  - upgraded allure from ^3.3.1 to ^3.4.0
  - upgraded allure-cypress from ^3.6.0 to ^3.7.0
  - upgraded cypress from ^15.11.0 to ^15.13.1

- electron-playwright:
  - upgraded @cucumber/cucumber from ^12.6.0 to ^12.7.0
  - upgraded @qavajs/html-formatter from ^1.0.0 to ^1.2.0
  - upgraded @qavajs/steps-playwright from ^2.14.1 to ^2.15.0
  - upgraded @qavajs/validation from ^1.6.1 to ^1.6.2
  - upgraded electron from ^40.4.1 to ^41.2.0